### PR TITLE
fix: resolve vtree init hanging issue with spinner overlap

### DIFF
--- a/velocitytree/cli.py
+++ b/velocitytree/cli.py
@@ -91,6 +91,7 @@ def init(ctx, template, name, force):
         # Check if config already exists
         config_path = Path('.velocitytree.yaml')
         if config_path.exists() and not force:
+            progress.stop()
             console.print("[yellow]⚠[/yellow] Configuration file already exists. Use --force to overwrite.")
             return
         
@@ -143,14 +144,17 @@ def init(ctx, template, name, force):
             progress.update(task, description=f"Created {template} workflow")
         
         progress.update(task, description="Project initialized successfully!")
-        console.print("[green]✓[/green] Project initialized!")
-        console.print(f"Configuration saved to: [blue]{config_path}[/blue]")
-        
-        # Automatically run onboarding wizard
-        console.print("\n[yellow]Starting setup wizard to configure AI providers and workflows...[/yellow]")
-        from .onboarding import OnboardingWizard
-        wizard = OnboardingWizard(ctx.obj['config'])
-        wizard.run()
+    
+    console.print("[green]✓[/green] Project initialized!")
+    console.print(f"Configuration saved to: [blue]{config_path}[/blue]")
+    
+    # Automatically run onboarding wizard without extra spinner
+    console.print("\n[yellow]Starting setup wizard to configure AI providers and workflows...[/yellow]")
+    import time
+    time.sleep(0.5)  # Brief pause before wizard
+    from .onboarding import OnboardingWizard
+    wizard = OnboardingWizard(ctx.obj['config'])
+    wizard.run()
 
 
 @cli.command()

--- a/velocitytree/onboarding.py
+++ b/velocitytree/onboarding.py
@@ -51,10 +51,12 @@ class OnboardingWizard:
         # Check if already configured
         if self._is_configured() and not reset:
             console.print("[yellow]Velocitytree is already configured![/yellow]")
-            if click.confirm("Would you like to reconfigure?"):
-                self._reset_configuration()
-            else:
+            # Clear any spinners
+            console.print()
+            if not click.confirm("Would you like to reconfigure?", default=False):
                 return
+            else:
+                self._reset_configuration()
         
         # Start onboarding flow
         self._show_welcome()


### PR DESCRIPTION
- Fix progress spinner overlap in init command
- Prevent spinner from continuing during wizard prompts
- Add clear separation between progress context and wizard
- Improve onboarding flow with explicit confirmation
- Add brief pause before wizard starts

🤖 Generated with [Claude Code](https://claude.ai/code)